### PR TITLE
Make doc build python < 3.5 compatible

### DIFF
--- a/docs/autodoc_example.py
+++ b/docs/autodoc_example.py
@@ -10,9 +10,7 @@ class MyClass:
     def my_coro(self):
         """ This is my coroutine """
 
-    async def my_async_func(self):
-        """ This is my async function """
 
-
-async def coro(param):
+@asyncio.coroutine
+def coro(param):
     """ Module level async function """

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -159,7 +159,7 @@ You can set directive options by adding it to `autocofunction` and
       :coroutine:
 
 .. autocofunction:: coro
-   :async-with:
+   :async-for:
    :coroutine:
 
 You can also force `coroutine` prefix on not-coroutine method by overriding it


### PR DESCRIPTION
Minor fix for wrong `async-with`